### PR TITLE
Request -- HOTFIX/MECHANICS/20241006

### DIFF
--- a/BlackFlags/Assets/Scripts/Data Core/Convoy.cs
+++ b/BlackFlags/Assets/Scripts/Data Core/Convoy.cs
@@ -34,6 +34,7 @@ namespace GameMechanics.Ships
         //protected NavMeshAgent _thisAgent;
         public NavMeshPath path;
         protected Vector3 _destination;
+        protected int pathProgressIndex = 0;
 
         //Raycast
         protected Ray _clickRay;
@@ -169,7 +170,8 @@ namespace GameMechanics.Ships
         public float CalculateRouteTime()
         {
             var time = 0f;
-            for (int i = 0; i < path.corners.Length - 1; i++)
+            time += Vector3.Distance(transform.position, path.corners[pathProgressIndex]) / convoySpeed;
+            for (int i = pathProgressIndex; i < path.corners.Length - 1; i++)
             {
                 time += Vector3.Distance(path.corners[i], path.corners[i + 1]) / convoySpeed;
             }

--- a/BlackFlags/Assets/Scripts/PlayerMovement.cs
+++ b/BlackFlags/Assets/Scripts/PlayerMovement.cs
@@ -278,7 +278,7 @@ public class PlayerMovement : Convoy
         mask = 1 << NavMesh.GetAreaFromName("Ocean");
         if (NavMesh.SamplePosition(position, out _hit, 1, mask))
         {
-            print("océano");
+            print("ocï¿½ano");
             return _hit.mask;
         }
         return 0;
@@ -326,7 +326,7 @@ public class PlayerMovement : Convoy
             }
             else if (thisConvoyTarget != null)
             {
-                print("no puede interceptar en ruta actual con una intercepción perfecta así que busca la mejor ruta optativa");
+                print("no puede interceptar en ruta actual con una intercepciï¿½n perfecta asï¿½ que busca la mejor ruta optativa");
                 Stop();
                 byte i = 5;
                 var targetPos = thisConvoyTarget.transform.position;
@@ -364,7 +364,7 @@ public class PlayerMovement : Convoy
         //Calculate Time now
         _remainingTime = CalculateRouteTime();
         _EVENT_refreshRouteTime(_remainingTime);
-        //print($"Tiempo: {_remainingTime} días");
+        //print($"Tiempo: {_remainingTime} dï¿½as");
 
         GameManager.gm.getCurrentEffect(transform);
     }
@@ -376,11 +376,11 @@ public class PlayerMovement : Convoy
         _thisConvoySpriteController.SetSprite();
         playerLookRotation(transform.rotation);
 
-        int i = 1;
-        while(i < waypoints.Length)
+        pathProgressIndex = 1;
+        while(pathProgressIndex < waypoints.Length)
         {
-            _destination = waypoints[i];
-            transform.rotation = Quaternion.LookRotation(waypoints[i] - transform.position);
+            _destination = waypoints[pathProgressIndex];
+            transform.rotation = Quaternion.LookRotation(waypoints[pathProgressIndex] - transform.position);
             if (Vector3.Distance(transform.position, _destination) < 0.215f)
             {
                 if (thisConvoyTarget != null)
@@ -393,27 +393,27 @@ public class PlayerMovement : Convoy
                         Stop();
                         //print("chased");
                     }
-                    else if(i < waypoints.Length - 1 && i != 1)
+                    else if(pathProgressIndex < waypoints.Length - 1 && pathProgressIndex != 1)
                     {
-                        if(Vector3.Distance(_destination, waypoints[i + 1]) > 0.5f)
+                        if(Vector3.Distance(_destination, waypoints[pathProgressIndex + 1]) > 0.5f)
                         {
                             var tempDest = Intercept(thisConvoyTarget);
-                            transform.rotation = Quaternion.LookRotation(waypoints[i + 1] - transform.position);
+                            transform.rotation = Quaternion.LookRotation(waypoints[pathProgressIndex + 1] - transform.position);
                             _thisConvoySpriteController.SetSprite();
                             CreatePath(tempDest);
                         }
                     }
                 }
-                i++;
-                if (i < waypoints.Length)
+                pathProgressIndex++;
+                if (pathProgressIndex < waypoints.Length)
                 {
-                    transform.rotation = Quaternion.LookRotation(waypoints[i] - transform.position);
+                    transform.rotation = Quaternion.LookRotation(waypoints[pathProgressIndex] - transform.position);
                     _thisConvoySpriteController.SetSprite();
                     playerLookRotation(transform.rotation);
                 }   
                 else //llega a destino
                 {
-                    //Borra la línea de rumbo trazado
+                    //Borra la lï¿½nea de rumbo trazado
                     ClearDrawing();
                     //Avisa a los crossmap que ya no hay un destino
                     ArriveToDestination();
@@ -545,7 +545,7 @@ public class PlayerMovement : Convoy
             shelter.convoysInThisPort.Add(this);
         }
         _EVENT_ArriveToPort(currentPort);
-        Dissappear(); //Parche para que el barco desaparezca, ya que llamar a este método desde el explorer no hace nada
+        Dissappear(); //Parche para que el barco desaparezca, ya que llamar a este mï¿½todo desde el explorer no hace nada
         GetComponent<BoxCollider>().enabled = false;
     }
     private void ExitCity()


### PR DESCRIPTION
Hotfix para la versión 0.032: Cambios en el cálculo de tiempo de ruta: ahora el tiempo restante en días se actualiza correctamente. Ahora se toma en cuenta la posición actual del jugador y el número de waypoints restantes en la ruta en curso.

Soluciona el siguiente error: "Una vez se calcula el tiempo de ruta, el valor no cambia a medida que pasan los días".
- Comportamiento esperado: Conforme transcurre el tiempo y el barco recorre su trayecto, el tiempo restante debe dismuir hasta llegar a cero.
- Comportamiento obtenido: No se estaba actualizando el número de días en el panel de interfaz.