### PR TITLE
Request Hotfix/mechanics/20241012

### DIFF
--- a/BlackFlags/Assets/Scripts/Data Core/Convoy.cs
+++ b/BlackFlags/Assets/Scripts/Data Core/Convoy.cs
@@ -187,13 +187,20 @@ namespace GameMechanics.Ships
             float C3 = Mathf.Pow(C1, 2) - 4 * C2;
             if (C3 < 0)
             {
-               //No solution
+                //No solution
                 return transform.position + target.transform.forward * 15;
             }
             else
             {
                 //Destination
-                float t = 2 * D / (C1 + Mathf.Sqrt(C3));
+                float t = Mathf.Abs(2 * D / (C1 + Mathf.Sqrt(C3)));
+
+                if(t < 0)
+                {
+                    //No solution
+                    return transform.position + target.transform.forward * 15;
+                }
+
                 return target.transform.position + target.transform.forward * t * target.convoySpeed;
             }
         }

--- a/BlackFlags/Assets/Scripts/GameManager.cs
+++ b/BlackFlags/Assets/Scripts/GameManager.cs
@@ -219,7 +219,7 @@ public class GameManager : MonoBehaviour
 
         if(currentsMapData.arrows[j, i].direction == 0) 
         {
-            print("no hay corriente");
+            // print("no hay corriente");
             return 0;
         }
 
@@ -232,8 +232,8 @@ public class GameManager : MonoBehaviour
         var dif = Mathf.Abs(Mathf.DeltaAngle(currentAngle, target.transform.rotation.eulerAngles.y));
 
         //Cálculo de la fuerza de corriente en base a la diferencia de �ngulo con el barco
-        print(dif);
-        print(Mathf.Clamp(1 - dif / 30, -1, 1) * currentsMapData.arrows[j, i].dragStrength);
+        // print(dif);
+        // print(Mathf.Clamp(1 - dif / 30, -1, 1) * currentsMapData.arrows[j, i].dragStrength);
         return Mathf.Clamp(1 - dif / 30, -1, 1) * currentsMapData.arrows[j, i].dragStrength;
     }
 }

--- a/BlackFlags/Assets/Scripts/PlayerMovement.cs
+++ b/BlackFlags/Assets/Scripts/PlayerMovement.cs
@@ -242,6 +242,7 @@ public class PlayerMovement : Convoy
                 }
                 else //the hit is out of vision, go to map point
                 {
+                    thisConvoyTarget = null;
                     CreatePath(_clickHit.point);
                 }
             }
@@ -328,12 +329,12 @@ public class PlayerMovement : Convoy
             {
                 print("no puede interceptar en ruta actual con una intercepci�n perfecta as� que busca la mejor ruta optativa");
                 Stop();
-                byte i = 5;
+                byte i = 16;
                 var targetPos = thisConvoyTarget.transform.position;
                 var dir = thisConvoyTarget.transform.forward;
                 while (i > 0)
                 {
-
+                    print(i);
                     if (CanGoTo(targetPos + dir * i))
                     {
                         CreatePath(targetPos + dir * i);


### PR DESCRIPTION
Hotfix para la versión 0.032: cambios al establecer ruta cuando el jugador persigue a un barco o convoy.

Soluciona el siguiente error: "Si perseguimos a un npc que tiene una velocidad mayor a la nuestra, es posible que nuestro barco tome un rumbo en dirección contraria al objetivo".
- Comportamiento esperado: cuando el usuario haga click derecho, se trazará un rumbo con el que se intente interceptar y alcanzar al objetivo. Si debido a la velocidad y trayecto del objetivo no es posible trazar un rumbo de colisión, se marca un punto en dirección al objetivo para intentar mantener la distancia con el objetivo.
- Comportamiento obtenido: cuando el usuario hace click sobre una unidad, el trayecto calculado nos lleva a alejarnos en dirección opuesta al objetivo.
- Naturaleza del error: Es posible que un trayecto de tiempo negativo sea una solución al triángulo de intersección obtenido al aplicar el teorema del coseno. 